### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,3 +1,6 @@
+permissions:
+  contents: read
+  packages: write
 name: Build F42 bootc image
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/CompPhy/framework-fedora-bootc/security/code-scanning/1](https://github.com/CompPhy/framework-fedora-bootc/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the job. Since the workflow pushes to the GitHub Container Registry, it needs `packages: write` permission. It also likely needs `contents: read` for actions like `actions/checkout`. The best way to fix this is to add the following block at the top level of the workflow (after the `name:` line and before `on:`), so it applies to all jobs unless overridden:

```yaml
permissions:
  contents: read
  packages: write
```

This ensures the workflow only has the permissions it needs, following the principle of least privilege. No other code or configuration changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
